### PR TITLE
feat(config): vcpu, ram cph in config

### DIFF
--- a/.default.env
+++ b/.default.env
@@ -17,3 +17,7 @@ INFLUXDB_DB=portal_prometheus
 # OS_CREDITS_WORKERS=10
 # Float precision of `credits_current` inside Perun
 # OS_CREDITS_PRECISION=2
+# Cost of running one vCPU core for one hour
+# VCPU_CREDIT_PER_HOUR=1
+# Cost of running one GB of RAM for one hour
+# RAM_CREDIT_PER_HOUR=0.3

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ docker-build-dev: ## Build Dockerfile.dev with name 'os_credits-dev'
 	find . -type d -name '__pycache__' -prune -exec rm -rf {} \;
 	docker build -f Dockerfile.dev -t os_credits-dev .
 
+.PHONY: build-run-dev
+build-run-dev: ## Build Dockerfile.dev with name 'os_credits-dev' and start docker-compose
+	find . -type d -name '__pycache__' -prune -exec rm -rf {} \;
+	docker build -f Dockerfile.dev -t os_credits-dev .
+	docker-compose up -d
+	docker stop os_credits_credits_1
+	docker start os_credits_credits_1
+
 .PHONY: docker-run-dev
 docker-run-dev: ## Run 'os_credits-dev' inside 'docker-compose.yml' attached - os_credits-dev:80 -> localhost:8000
 	poetry run docker-compose up 

--- a/src/os_credits/credits/base_models.py
+++ b/src/os_credits/credits/base_models.py
@@ -206,7 +206,7 @@ class TotalUsageMetric(
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def costs_per_hour(cls, spec: int) -> Credits:
+    def costs_per_hour(cls, spec: Decimal) -> Credits:
         return Credits(
             (spec * cls.CREDITS_PER_VIRTUAL_HOUR).quantize(
                 config["OS_CREDITS_PRECISION"]

--- a/src/os_credits/credits/models.py
+++ b/src/os_credits/credits/models.py
@@ -13,11 +13,12 @@ from .base_models import Credits
 from .base_models import Metric
 from .base_models import TotalUsageMetric
 from .base_models import UsageMeasurement
+from os_credits.settings import config
 
 
 class VCPUMetric(TotalUsageMetric, name="project_vcpu_usage", friendly_name="cpu"):
 
-    CREDITS_PER_VIRTUAL_HOUR = Decimal(1)
+    CREDITS_PER_VIRTUAL_HOUR = config["VCPU_CREDIT_PER_HOUR"]
     description = "Amount of vCPUs."
 
 
@@ -25,7 +26,7 @@ class RAMMetric(TotalUsageMetric, name="project_mb_usage", friendly_name="ram"):
 
     # always specify the amount as string to prevent inaccuracies of builtin float
     # division by 1024 to compensate for the usage of MiB instead of GiB
-    CREDITS_PER_VIRTUAL_HOUR = Decimal("0.3") / Decimal(1024)
+    CREDITS_PER_VIRTUAL_HOUR = config["RAM_CREDIT_PER_HOUR"]
     description = (
         "Amount of RAM in MiB, meaning *1024 instead of *1000. Modeled this "
         "way since the same unit is used by OpenStack for its "

--- a/src/os_credits/credits/tasks.py
+++ b/src/os_credits/credits/tasks.py
@@ -326,7 +326,6 @@ async def update_credits(
     await group.save()
     half_of_credits_granted = Decimal(group.credits_granted.value) / 2
     if (
-        previous_group_credits <= half_of_credits_granted
-        and group.credits_used.value > half_of_credits_granted
+        previous_group_credits <= half_of_credits_granted < group.credits_used.value
     ):
         raise HalfOfCreditsLeft(group)

--- a/src/os_credits/settings.py
+++ b/src/os_credits/settings.py
@@ -140,6 +140,18 @@ class Config(TypedDict):
         new InfluxDB lines put into queue by the endpoint handler.
 
         Default: ``10``
+
+    .. envvar:: VCPU_CREDIT_PER_HOUR
+
+        Cost of running one vCPU core for one hour.
+
+        Default: ``1``
+
+    .. envvar:: RAM_CREDIT_PER_HOUR
+
+        Cost of running one GB of RAM for one hour.
+
+        Default: ``0.3 / 1024``
     """
 
     CLOUD_GOVERNANCE_MAIL: str
@@ -163,6 +175,8 @@ class Config(TypedDict):
     OS_CREDITS_PRECISION: Decimal
     OS_CREDITS_PROJECT_WHITELIST: Optional[Set[str]]
     OS_CREDITS_WORKERS: int
+    VCPU_CREDIT_PER_HOUR: Decimal
+    RAM_CREDIT_PER_HOUR: Decimal
 
 
 default_config = Config(
@@ -186,6 +200,8 @@ default_config = Config(
     OS_CREDITS_PRECISION=Decimal(10) ** -2,
     OS_CREDITS_PROJECT_WHITELIST=None,
     OS_CREDITS_WORKERS=10,
+    VCPU_CREDIT_PER_HOUR=Decimal(1),
+    RAM_CREDIT_PER_HOUR=Decimal("0.3") / Decimal(1024),
 )
 
 
@@ -242,9 +258,50 @@ def parse_config_from_environment() -> Config:
             # value from the environment but rather the default one
             del environ[int_value_key]
 
+    for decimal_value_key in [
+        "VCPU_CREDIT_PER_HOUR",
+        "RAM_CREDIT_PER_HOUR",
+    ]:
+        try:
+            decimal_value = Decimal(environ[decimal_value_key])
+            if decimal_value < 0:
+                internal_logger.warning(
+                    "Decimal value (%s) must not be negative, falling back to default "
+                    "value",
+                    decimal_value_key,
+                )
+                del environ[decimal_value_key]
+                continue
+            PROCESSED_ENV_CONFIG.update({decimal_value_key: decimal_value})
+            internal_logger.debug(f"Added {decimal_value_key} to procssed env")
+        except KeyError:
+            # Environment variable not set, that's ok
+            pass
+        except ValueError:
+            internal_logger.warning(
+                "Could not convert value of $%s('%s') to Decimal",
+                decimal_value_key,
+                environ[decimal_value_key],
+            )
+            # since we cannot use a subset of the actual environment, see below, we have
+            # to remove invalid keys from environment to make sure that if such a key is
+            # looked up inside the config the chainmap does not return the unprocessed
+            # value from the environment but rather the default one
+            del environ[decimal_value_key]
+
     if "OS_CREDITS_PRECISION" in PROCESSED_ENV_CONFIG:
         PROCESSED_ENV_CONFIG["OS_CREDITS_PRECISION"] = (
             Decimal(10) ** -PROCESSED_ENV_CONFIG["OS_CREDITS_PRECISION"]
+        )
+
+    if "VCPU_CREDIT_PER_HOUR" in PROCESSED_ENV_CONFIG:
+        PROCESSED_ENV_CONFIG["VCPU_CREDIT_PER_HOUR"] = (
+            Decimal(PROCESSED_ENV_CONFIG["VCPU_CREDIT_PER_HOUR"])
+        )
+
+    if "RAM_CREDIT_PER_HOUR" in PROCESSED_ENV_CONFIG:
+        PROCESSED_ENV_CONFIG["RAM_CREDIT_PER_HOUR"] = (
+            Decimal(PROCESSED_ENV_CONFIG["RAM_CREDIT_PER_HOUR"]) / Decimal(1024)
         )
 
     # this would be the right way but makes pytest hang forever -.-'

--- a/src/os_credits/views.py
+++ b/src/os_credits/views.py
@@ -394,6 +394,7 @@ async def costs_per_hour(request: web.Request) -> web.Response:
     costs_per_hour = Decimal(0)
     for friendly_name, spec in machine_specs.items():
         try:
+            spec = Decimal(spec)
             costs_per_hour += Metric.metrics_by_friendly_name[
                 friendly_name
             ].costs_per_hour(spec)


### PR DESCRIPTION
@dweinholz 
- new make command for starting os_credits dev only
- adjust calculating of credits per hour for decimal spec instead of int
- cost per hour of vcpu and ram now settable in env file